### PR TITLE
Add Ke-MLS publication to publications list

### DIFF
--- a/app/components/publications.tsx
+++ b/app/components/publications.tsx
@@ -136,6 +136,38 @@ export default function Publications() {
           {/* Optional short description here */}
         </p>
       </div>
+
+      {/* 5. Ke-MLS – Environment and Planning B */}
+      <div
+        data-aos="zoom-in-up"
+        className="bg-zinc-300 text-black rounded-md p-4 my-2"
+      >
+        <h2 className="text-md mb-2 italic">
+          5. Vaibhav Kumar, Bharat Lohani,{" "}
+          <span className="font-bold">Pyare Lal</span>, Aakash Singh Bais and
+          Aditya, &quot;Ke-MLS: A large-scale labeled mobile Lidar data set from
+          Indian urban region,&quot;
+          <span className="ml-1 italic">
+            Environment and Planning B: Urban Analytics and City Science
+          </span>
+          , 2026,
+          <a
+            href="https://doi.org/10.1177/23998083261430812"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline ml-1"
+          >
+            doi: 10.1177/23998083261430812
+          </a>
+          .
+          <span className="text-sm text-teal-800 font-mono bg-teal-100 inline rounded-full px-2 align-top float-right animate-pulse">
+            Journal • 2026
+          </span>
+        </h2>
+        <p className="p-4 font-medium text-sm md:text-md">
+          {/* Optional short description here */}
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Added a new publication entry to the Publications component for the Ke-MLS dataset paper published in Environment and Planning B: Urban Analytics and City Science.

## Key Changes
- Added a new publication card (item #5) featuring the Ke-MLS paper by Vaibhav Kumar, Bharat Lohani, Pyare Lal, and others
- Included full citation with DOI link (10.1177/23998083261430812)
- Added publication metadata badge indicating "Journal • 2026"
- Maintained consistent styling with existing publication entries using the same component structure and Tailwind CSS classes

## Implementation Details
- Used the existing publication card template with `data-aos="zoom-in-up"` animation
- Applied consistent styling: zinc-300 background with black text and rounded corners
- Included a pulsing badge to highlight the publication year and type
- DOI link opens in a new tab with proper security attributes (`noopener noreferrer`)
- Left space for optional description (currently commented out, matching other entries)

https://claude.ai/code/session_01BxSASCnJi3t4pn3PaVPY9E